### PR TITLE
feature/workflow-notification-2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,8 @@ argo-stack:
 		argo-stack ./helm/argo-stack -n argocd --create-namespace \
 		--wait --atomic --timeout 10m0s \
 		--set-string events.github.webhook.ingress.hosts[0]=${ARGO_HOSTNAME} \
-		--set-string events.github.webhook.url=https://${ARGO_HOSTNAME}/events\
+		--set-string events.github.webhook.url=https://${ARGO_HOSTNAME}/events \
+		--set-string workflows.baseUrl=https://${ARGO_HOSTNAME} \
 		--set-string s3.enabled=${S3_ENABLED} \
 		--set-string s3.bucket=${S3_BUCKET} \
 		--set-string s3.pathStyle=true \

--- a/docs/adr/ADR-Workflow-GitHub-Status.md
+++ b/docs/adr/ADR-Workflow-GitHub-Status.md
@@ -1,4 +1,4 @@
-# ADR: Workflow → GitHub Status Integration via ClusterWorkflowTemplate
+# ADR 0003: Workflow → GitHub Status Integration via ClusterWorkflowTemplate
 
 ## Status
 Accepted
@@ -26,8 +26,8 @@ sequenceDiagram
     participant GSP as github-status-proxy
     participant GH as GitHub
 
-    WF->>CWT: onExit notify-github<br/>event=workflow-{phase}
-    CWT->>GSP: HTTP POST /workflow<br/>JSON payload with repo-url, git-sha, tenant
+    WF->>CWT: onExit notify-github
+    event=workflow-{phase}
     GSP->>GSP: Resolve installation via RepoRegistration
     GSP->>GH: Post commit status
     GH-->>User: Status visible on commit/PR
@@ -62,9 +62,9 @@ spec:
             "phase": "{{workflow.status.phase}}",
             "labels": {{toJson workflow.labels}},
             "annotations": {{toJson workflow.annotations}},
-            "status": {{ toJson .workflow.status }},
-            "startedAt": "{{.workflow.status.startedAt}}",
-            "finishedAt": "{{.workflow.status.finishedAt}}"
+            "status": {{toJson workflow.status}},
+            "startedAt": "{{workflow.status.startedAt}}",
+            "finishedAt": "{{workflow.status.finishedAt}}"
           }
 
 ```

--- a/docs/adr/ADR-Workflow-GitHub-Status.md
+++ b/docs/adr/ADR-Workflow-GitHub-Status.md
@@ -1,0 +1,88 @@
+# ADR: Workflow → GitHub Status Integration via ClusterWorkflowTemplate
+
+## Status
+Accepted
+
+## Context
+Argo Workflows run in multiple namespaces and need a centralized way to 
+emit workflow lifecycle events to GitHub using tenant-specific GitHub App 
+credentials stored via RepoRegistration.
+
+## Decision
+Use a `ClusterWorkflowTemplate` to define a shared notification template.
+Workflows reference this via `onExit` handlers.
+
+Notification events:
+- workflow-pending
+- workflow-succeeded
+- workflow-failed
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+    participant WF as Workflow
+    participant CWT as ClusterWorkflowTemplate
+    participant GSP as github-status-proxy
+    participant GH as GitHub
+
+    WF->>CWT: onExit notify-github<br/>event=workflow-{phase}
+    CWT->>GSP: HTTP POST /workflow<br/>JSON payload with repo-url, git-sha, tenant
+    GSP->>GSP: Resolve installation via RepoRegistration
+    GSP->>GH: Post commit status
+    GH-->>User: Status visible on commit/PR
+```
+
+## Consequences
+- Centralizes workflow→GitHub logic
+- Prevents per-namespace duplication
+- Integrates with existing RepoRegistration and GitHub App setup
+
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: github-status-notify
+spec:
+  templates:
+    - name: notify-github-status
+      inputs:
+        parameters:
+          - name: event
+      http:
+        url: http://github-status-proxy.argocd.svc.cluster.local/workflow
+        method: POST
+        body: |
+          {
+            "kind": "workflow",
+            "event": "{{inputs.parameters.event}}",
+            "workflowName": "{{workflow.name}}",
+            "namespace": "{{workflow.namespace}}",
+            "phase": "{{workflow.status.phase}}",
+            "labels": {{toJson workflow.labels}},
+            "annotations": {{toJson workflow.annotations}},
+            "status": {{ toJson .workflow.status }},
+            "startedAt": "{{.workflow.status.startedAt}}",
+            "finishedAt": "{{.workflow.status.finishedAt}}"
+          }
+
+```
+
+```go
+// WorkflowEvent describes the JSON payload sent by Argo Workflows notifications.
+// It matches the templates we discussed earlier.
+type WorkflowEvent struct {
+	Kind        string            `json:"kind"`        // "workflow"
+	Event       string            `json:"event"`       // "workflow-pending" | "workflow-succeeded" | "workflow-failed"
+	Workflow    string            `json:"workflowName"`
+	Namespace   string            `json:"namespace"`
+	Phase       string            `json:"phase"`
+	StartedAt   string            `json:"startedAt,omitempty"`
+	FinishedAt  string            `json:"finishedAt,omitempty"`
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+	// Status is intentionally left as raw JSON so we don't need a full struct.
+	Status any `json:"status"`
+}
+```

--- a/docs/adr/ADR-Workflow-GitHub-Status.md
+++ b/docs/adr/ADR-Workflow-GitHub-Status.md
@@ -86,3 +86,11 @@ type WorkflowEvent struct {
 	Status any `json:"status"`
 }
 ```
+
+## References
+
+- [Argo Workflows: ClusterWorkflowTemplate](https://argo-workflows.readthedocs.io/en/latest/cluster-workflow-templates/)
+- [Argo Workflows: HTTP Template](https://argo-workflows.readthedocs.io/en/latest/http-template/)
+- [Argo Workflows: Workflow Lifecycle Hooks](https://argo-workflows.readthedocs.io/en/latest/lifecyclehook/)
+- [GitHub Issue #128](https://github.com/calypr/argo-helm/issues/128)
+- [ADR 0001: GitHub Status Proxy](0001-github-status-proxy-for-multi-tenant-github-apps.md)

--- a/github-status-proxy/main_test.go
+++ b/github-status-proxy/main_test.go
@@ -139,3 +139,173 @@ func TestValidateRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateWorkflowEvent(t *testing.T) {
+	tests := []struct {
+		name    string
+		event   WorkflowEvent
+		wantErr bool
+	}{
+		{
+			name: "Valid workflow event",
+			event: WorkflowEvent{
+				Kind:      "workflow",
+				Event:     "workflow-succeeded",
+				Workflow:  "test-workflow",
+				Namespace: "default",
+				Phase:     "Succeeded",
+				Labels: map[string]string{
+					"calypr.io/commit-sha": "abc123",
+					"calypr.io/repo":       "calypr/argo-helm",
+				},
+				Annotations: map[string]string{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Missing kind",
+			event: WorkflowEvent{
+				Event:     "workflow-succeeded",
+				Workflow:  "test-workflow",
+				Namespace: "default",
+				Phase:     "Succeeded",
+				Labels:    map[string]string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Wrong kind",
+			event: WorkflowEvent{
+				Kind:      "task",
+				Event:     "workflow-succeeded",
+				Workflow:  "test-workflow",
+				Namespace: "default",
+				Phase:     "Succeeded",
+				Labels:    map[string]string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Missing event",
+			event: WorkflowEvent{
+				Kind:      "workflow",
+				Workflow:  "test-workflow",
+				Namespace: "default",
+				Phase:     "Succeeded",
+				Labels:    map[string]string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Missing workflow name",
+			event: WorkflowEvent{
+				Kind:      "workflow",
+				Event:     "workflow-succeeded",
+				Namespace: "default",
+				Phase:     "Succeeded",
+				Labels:    map[string]string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Missing namespace",
+			event: WorkflowEvent{
+				Kind:     "workflow",
+				Event:    "workflow-succeeded",
+				Workflow: "test-workflow",
+				Phase:    "Succeeded",
+				Labels:   map[string]string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Missing phase",
+			event: WorkflowEvent{
+				Kind:      "workflow",
+				Event:     "workflow-succeeded",
+				Workflow:  "test-workflow",
+				Namespace: "default",
+				Labels:    map[string]string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Nil labels",
+			event: WorkflowEvent{
+				Kind:      "workflow",
+				Event:     "workflow-succeeded",
+				Workflow:  "test-workflow",
+				Namespace: "default",
+				Phase:     "Succeeded",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWorkflowEvent(&tt.event)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateWorkflowEvent() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMapWorkflowPhaseToGitHubState(t *testing.T) {
+	tests := []struct {
+		name      string
+		phase     string
+		wantState string
+	}{
+		{
+			name:      "Succeeded phase",
+			phase:     "Succeeded",
+			wantState: "success",
+		},
+		{
+			name:      "Failed phase",
+			phase:     "Failed",
+			wantState: "failure",
+		},
+		{
+			name:      "Error phase",
+			phase:     "Error",
+			wantState: "failure",
+		},
+		{
+			name:      "Running phase",
+			phase:     "Running",
+			wantState: "pending",
+		},
+		{
+			name:      "Pending phase",
+			phase:     "Pending",
+			wantState: "pending",
+		},
+		{
+			name:      "Unknown phase",
+			phase:     "Unknown",
+			wantState: "error",
+		},
+		{
+			name:      "Lowercase succeeded",
+			phase:     "succeeded",
+			wantState: "success",
+		},
+		{
+			name:      "Lowercase failed",
+			phase:     "failed",
+			wantState: "failure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := mapWorkflowPhaseToGitHubState(tt.phase)
+			if state != tt.wantState {
+				t.Errorf("mapWorkflowPhaseToGitHubState() = %v, want %v", state, tt.wantState)
+			}
+		})
+	}
+}

--- a/helm/argo-stack/templates/11-tenant-rbac-from-repo-registrations.yaml
+++ b/helm/argo-stack/templates/11-tenant-rbac-from-repo-registrations.yaml
@@ -145,5 +145,53 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: {{ $.Values.namespaces.argoEvents | default "argo-events" }}
+---
+# the agent pod wants to load a pod, needs service acct token
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wf-runner.service-account-token
+  namespace: {{ $namespace }}
+  annotations:
+    kubernetes.io/service-account.name: wf-runner
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "10"
+    helm.sh/hook-delete-policy: before-hook-creation    
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: wf-runner-workflowtasksets
+  namespace: {{ $namespace }}
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources:
+      - workflowtasksets
+      - workflowtasksets/status
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      # you generally don't need create/delete from the runner,
+      # but it's harmless if you include them:
+      # - create
+      # - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: wf-runner-workflowtasksets-binding
+  namespace: {{ $namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: wf-runner-workflowtasksets
+subjects:
+  - kind: ServiceAccount
+    name: wf-runner
+    namespace: {{ $namespace }}
 {{- end }}
 {{- end }}

--- a/helm/argo-stack/templates/argocd/notifications-cm.yaml
+++ b/helm/argo-stack/templates/argocd/notifications-cm.yaml
@@ -36,7 +36,7 @@ data:
             "repo_url": "{{`{{.app.spec.source.repoURL}}`}}",
             "sha": "{{`{{.app.status.sync.revision}}`}}",
             "state": "success",
-            "context": "argocd/{{`{{.app.metadata.name}}`}}",
+            "context": "applications/{{`{{.app.metadata.name}}`}}",
             "target_url": "{{ $argocdUrl }}/{{`{{.app.metadata.name}}`}}",
             "description": "Application synced successfully"
           }
@@ -52,7 +52,7 @@ data:
             "repo_url": "{{`{{.app.spec.source.repoURL}}`}}",
             "sha": "{{`{{.app.status.sync.revision}}`}}",
             "state": "failure",
-            "context": "argocd/{{`{{.app.metadata.name}}`}}",
+            "context": "applications/{{`{{.app.metadata.name}}`}}",
             "target_url": "{{ $argocdUrl }}/{{`{{.app.metadata.name}}`}}",
             "description": "Application sync failed"
           }
@@ -68,7 +68,7 @@ data:
             "repo_url": "{{`{{.app.spec.source.repoURL}}`}}",
             "sha": "{{`{{.app.status.sync.revision}}`}}",
             "state": "pending",
-            "context": "argocd/{{`{{.app.metadata.name}}`}}",
+            "context": "applications/{{`{{.app.metadata.name}}`}}",
             "target_url": "{{ $argocdUrl }}/{{`{{.app.metadata.name}}`}}",
             "description": "Application sync in progress"
           }
@@ -84,7 +84,7 @@ data:
             "repo_url": "{{`{{.app.spec.source.repoURL}}`}}",
             "sha": "{{`{{.app.status.sync.revision}}`}}",
             "state": "success",
-            "context": "argocd/{{`{{.app.metadata.name}}`}}/deployed",
+            "context": "applications/{{`{{.app.metadata.name}}`}}/deployed",
             "target_url": "{{ $argocdUrl }}/{{`{{.app.metadata.name}}`}}",
             "description": "Application deployed successfully"
           }

--- a/helm/argo-stack/templates/events/sensor-github-push.yaml
+++ b/helm/argo-stack/templates/events/sensor-github-push.yaml
@@ -60,9 +60,15 @@ spec:
                     value: {{ $reg.name | quote }}
                   - name: repo-url
                     value: {{ $reg.repoUrl | quote }}
-                  # TODO - read from event
-                  # - name: revision
-                  #  value: main
+                  # Populated from GitHub webhook
+                  - name: installation-id
+                    value: ""          # body.installation.id
+                  - name: git-ref
+                    value: ""          # body.ref
+                  - name: git-before
+                    value: ""          # body.before
+                  - name: git-after
+                    value: ""          # body.after (commit SHA)
                   {{- if $reg.artifactBucket }}
                   - name: artifact-bucket
                     value: {{ $reg.artifactBucket.bucket | quote }}
@@ -71,6 +77,35 @@ spec:
                   - name: artifact-region
                     value: {{ $reg.artifactBucket.region | quote }}
                   {{- end }}
+        parameters:
+          # Map GitHub webhook -> workflow arguments
+          # index 0: repo-name (static)
+          # index 1: repo-url (static)
+
+          # installation.id -> parameters[2].value
+          - src:
+              dependencyName: {{ $eventName | quote }}
+              dataKey: body.installation.id
+            dest: spec.arguments.parameters.2.value
+
+          # ref -> parameters[3].value
+          - src:
+              dependencyName: {{ $eventName | quote }}
+              dataKey: body.ref
+            dest: spec.arguments.parameters.3.value
+
+          # before -> parameters[4].value
+          - src:
+              dependencyName: {{ $eventName | quote }}
+              dataKey: body.before
+            dest: spec.arguments.parameters.4.value
+
+          # after -> parameters[5].value
+          - src:
+              dependencyName: {{ $eventName | quote }}
+              dataKey: body.after
+            dest: spec.arguments.parameters.5.value
   {{- end }}
 {{- end }}
 {{- end }}
+

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
@@ -18,10 +18,6 @@ metadata:
 spec:
   templates:
     - name: notify-github-status
-      inputs:
-        parameters:
-          - name: phase
-            description: "Workflow status phase (e.g., Succeeded, Failed, Pending)"
       http:
         url: http://github-status-proxy.{{ .Values.namespaces.argocd }}.svc.cluster.local/workflow
         method: POST
@@ -31,10 +27,10 @@ spec:
         body: |
           {
             "kind": "workflow",
-            "event": "workflow-{{`{{inputs.parameters.phase}}`}}",
+            "event": "workflow-{{`{{workflow.status.phase}}`}}",
             "workflowName": "{{`{{workflow.name}}`}}",
             "namespace": "{{`{{workflow.namespace}}`}}",
-            "phase": "{{`{{inputs.parameters.phase}}`}}",
+            "phase": "{{`{{workflow.status.phase}}`}}",
             "labels": {{`{{toJson workflow.labels}}`}},
             "annotations": {{`{{toJson workflow.annotations}}`}},
             "status": {{`{{toJson workflow.status}}`}},

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
@@ -38,8 +38,6 @@ spec:
             "labels": {{`{{toJson workflow.labels}}`}},
             "annotations": {{`{{toJson workflow.annotations}}`}},
             "status": {{`{{toJson workflow.status}}`}},
-            "startedAt": "{{`{{workflow.status.startedAt}}`}}",
-            "finishedAt": "{{`{{workflow.status.finishedAt}}`}}",
             "target_url": "{{ .Values.workflows.baseUrl }}/workflows/{{`{{workflow.namespace}}`}}/{{`{{workflow.name}}`}}"
           }
 

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
@@ -1,0 +1,45 @@
+{{- /*
+ClusterWorkflowTemplate for GitHub Status Notifications
+Provides a centralized notification mechanism for workflows across all namespaces.
+See ADR 0003 for design rationale.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: github-status-notify
+  labels:
+    app.kubernetes.io/name: argo-stack
+    app.kubernetes.io/part-of: argo-workflows
+    app.kubernetes.io/component: notifications
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "10"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  templates:
+    - name: notify-github-status
+      inputs:
+        parameters:
+          - name: event
+            description: "Event type: workflow-{phase} where phase is the workflow status phase (e.g., workflow-Succeeded, workflow-Failed)"
+      http:
+        url: http://github-status-proxy.{{ .Values.namespaces.argocd }}.svc.cluster.local/workflow
+        method: POST
+        headers:
+          - name: Content-Type
+            value: "application/json"
+        body: |
+          {
+            "kind": "workflow",
+            "event": "{{`{{inputs.parameters.event}}`}}",
+            "workflowName": "{{`{{workflow.name}}`}}",
+            "namespace": "{{`{{workflow.namespace}}`}}",
+            "phase": "{{`{{workflow.status.phase}}`}}",
+            "labels": {{`{{toJson workflow.labels}}`}},
+            "annotations": {{`{{toJson workflow.annotations}}`}},
+            "status": {{`{{toJson workflow.status}}`}},
+            "startedAt": "{{`{{workflow.status.startedAt}}`}}",
+            "finishedAt": "{{`{{workflow.status.finishedAt}}`}}",
+            "target_url": "{{ .Values.workflows.baseUrl }}/workflows/{{`{{workflow.namespace}}`}}/{{`{{workflow.name}}`}}"
+          }
+

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
@@ -20,8 +20,8 @@ spec:
     - name: notify-github-status
       inputs:
         parameters:
-          - name: event
-            description: "Event type: workflow-{phase} where phase is the workflow status phase (e.g., workflow-Succeeded, workflow-Failed)"
+          - name: phase
+            description: "Workflow status phase (e.g., Succeeded, Failed, Pending)"
       http:
         url: http://github-status-proxy.{{ .Values.namespaces.argocd }}.svc.cluster.local/workflow
         method: POST
@@ -31,10 +31,10 @@ spec:
         body: |
           {
             "kind": "workflow",
-            "event": "{{`{{inputs.parameters.event}}`}}",
+            "event": "workflow-{{`{{inputs.parameters.phase}}`}}",
             "workflowName": "{{`{{workflow.name}}`}}",
             "namespace": "{{`{{workflow.namespace}}`}}",
-            "phase": "{{`{{workflow.status.phase}}`}}",
+            "phase": "{{`{{inputs.parameters.phase}}`}}",
             "labels": {{`{{toJson workflow.labels}}`}},
             "annotations": {{`{{toJson workflow.annotations}}`}},
             "status": {{`{{toJson workflow.status}}`}},

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-rbac.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-rbac.yaml
@@ -78,5 +78,41 @@ subjects:
   - kind: ServiceAccount
     name: wf-runner
     namespace: {{ $namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argo-workflows-controller
+  namespace: {{ $namespace }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation  
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources:
+      - workflows
+      - workflows/finalizers
+      - workflowtasksets
+      - workflowtasksets/status
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-workflows-controller-binding
+  namespace: {{ $namespace }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation  
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-workflows-controller
+subjects:
+  - kind: ServiceAccount
+    name: argo-stack-argo-workflows-workflow-controller
+    namespace: argo-workflows
 {{- end }}
 {{- end }}

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-rbac.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-rbac.yaml
@@ -1,0 +1,82 @@
+{{- /*
+ClusterRole and ClusterRoleBinding for accessing ClusterWorkflowTemplates
+This allows Argo Events sensors and workflow service accounts to reference
+ClusterWorkflowTemplates when submitting and executing workflows.
+See ADR 0003 for context on ClusterWorkflowTemplate-based notifications.
+*/ -}}
+---
+# ClusterRole for reading ClusterWorkflowTemplates
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusterworkflowtemplate-reader
+  labels:
+    app.kubernetes.io/name: argo-stack
+    app.kubernetes.io/part-of: argo-workflows
+    app.kubernetes.io/component: rbac
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources: ["clusterworkflowtemplates"]
+    verbs: ["get", "list", "watch"]
+
+---
+# ClusterRoleBinding for Argo Events sensor service account
+# This allows sensors to submit workflows that reference ClusterWorkflowTemplates
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argo-events-clusterworkflowtemplate-reader
+  labels:
+    app.kubernetes.io/name: argo-stack
+    app.kubernetes.io/part-of: argo-workflows
+    app.kubernetes.io/component: rbac
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterworkflowtemplate-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.events.github.sensorServiceAccount | default "default" }}
+    namespace: {{ .Values.namespaces.argoEvents | default "argo-events" }}
+
+{{- if .Values.repoRegistrations }}
+{{- range $reg := .Values.repoRegistrations }}
+{{- $namespace := include "argo-stack.repoRegistration.namespace" $reg }}
+---
+# ClusterRoleBinding for workflow runner service account in tenant namespace: {{ $reg.name }}
+# This allows workflows to execute templates that reference ClusterWorkflowTemplates
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wf-runner-clusterworkflowtemplate-{{ $reg.name }}
+  labels:
+    app.kubernetes.io/name: {{ $reg.name }}
+    app.kubernetes.io/part-of: argo-stack
+    app.kubernetes.io/component: rbac
+    {{- if $reg.tenant }}
+    tenant: {{ $reg.tenant }}
+    {{- end }}
+    source: repo-registration
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation
+    repo-registration/name: {{ $reg.name | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterworkflowtemplate-reader
+subjects:
+  - kind: ServiceAccount
+    name: wf-runner
+    namespace: {{ $namespace }}
+{{- end }}
+{{- end }}

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -72,10 +72,6 @@ spec:
               name: github-status-notify
               template: notify-github-status
               clusterScope: true
-            arguments:
-              parameters:
-                - name: phase
-                  value: "{{`{{workflow.status.phase}}`}}"
     
     - name: run-nextflow
       metadata:

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -74,8 +74,8 @@ spec:
               clusterScope: true
             arguments:
               parameters:
-                - name: event
-                  value: "workflow-{{`{{workflow.status.phase}}`}}"
+                - name: phase
+                  value: "{{`{{workflow.status.phase}}`}}"
     
     - name: run-nextflow
       metadata:

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -65,13 +65,27 @@ spec:
 
   templates:
     # Exit handler template for GitHub notifications
+    # Using inline HTTP template instead of templateRef to avoid variable resolution issues
+    # at workflow submission time. workflow.status is only available at exit time.
     - name: notify-github-exit
-      steps:
-        - - name: notify-status
-            templateRef:
-              name: github-status-notify
-              template: notify-github-status
-              clusterScope: true
+      http:
+        url: http://github-status-proxy.{{ $.Values.namespaces.argocd }}.svc.cluster.local/workflow
+        method: POST
+        headers:
+          - name: Content-Type
+            value: "application/json"
+        body: |
+          {
+            "kind": "workflow",
+            "event": "workflow-{{`{{workflow.status.phase}}`}}",
+            "workflowName": "{{`{{workflow.name}}`}}",
+            "namespace": "{{`{{workflow.namespace}}`}}",
+            "phase": "{{`{{workflow.status.phase}}`}}",
+            "labels": {{`{{toJson workflow.labels}}`}},
+            "annotations": {{`{{toJson workflow.annotations}}`}},
+            "status": {{`{{toJson workflow.status}}`}},
+            "target_url": "{{ $.Values.workflows.baseUrl }}/workflows/{{`{{workflow.namespace}}`}}/{{`{{workflow.name}}`}}"
+          }
     
     - name: run-nextflow
       metadata:

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -33,11 +33,11 @@ spec:
         description: "Git repo containing the Nextflow pipeline."
         value: {{ $reg.repoUrl | quote }}
       - name: revision
-        description: "Git revision (branch, tag, or SHA) to run."
+        description: "Git revision (branch, tag, or SHA) to run. If git-ref is provided, it takes precedence."
         value: {{ $reg.defaultBranch | default "main" | quote }}
       - name: commit-sha
-        description: "Git commit SHA that the workflow is executing."
-        value: ""
+        description: "Git commit SHA that the workflow is executing. If set, takes precedence over git-ref and revision."
+        value: "{{`{{workflow.parameters.git-after}}`}}"
       - name: pipeline-file
         description: "Nextflow pipeline entry point file (e.g., main.nf, workflow.nf, pipeline.nf)."
         value: "pipelines/push/main.nf"
@@ -59,17 +59,66 @@ spec:
         {{- if $reg.artifactBucket }}
         value: {{ $reg.artifactBucket.region | quote }}
         {{- end }}
+      - name: installation-id
+        description: "GitHub App installation ID from webhook (installation.id)."
+        value: ""
+      - name: git-ref
+        description: "Git ref from webhook (ref), e.g. refs/heads/main."
+        value: ""
+      - name: git-before
+        description: "Previous commit SHA from webhook (before)."
+        value: ""
+      - name: git-after
+        description: "New commit SHA from webhook (after)."
+        value: ""
 
   # Exit handler for GitHub status notifications
   onExit: notify-github-exit
 
   templates:
     # Exit handler template for GitHub notifications
-    # Using inline HTTP template instead of templateRef to avoid variable resolution issues
-    # at workflow submission time. workflow.status is only available at exit time.
+    # Passes workflow.status as arguments to avoid early validation at submission time
+    # workflow.status is only available at exit time, not at submission time
     - name: notify-github-exit
+      steps:
+      - - name: send-notification
+          template: send-github-status
+          arguments:
+            parameters:
+            - name: workflow-name
+              value: "{{`{{workflow.name}}`}}"
+            - name: namespace
+              value: "{{`{{workflow.namespace}}`}}"
+            - name: repo-url
+              value: "{{`{{workflow.parameters.repo-url}}`}}"
+            - name: labels
+              value: "{{`{{workflow.labels}}`}}"
+            - name: annotations
+              value: "{{`{{workflow.annotations}}`}}"
+            - name: status
+              value: "{{`{{workflow.status}}`}}"
+            - name: installation-id
+              value: "{{`{{workflow.parameters.installation-id}}`}}"
+            - name: commit-sha
+              value: "{{`{{workflow.parameters.commit-sha}}`}}"
+
+    
+    # HTTP template for sending GitHub status notification
+    # Receives workflow data as inputs to avoid validation errors at submission time
+    - name: send-github-status
+      inputs:
+        parameters:
+        - name: workflow-name
+        - name: namespace
+        - name: repo-url
+        - name: labels
+        - name: annotations
+        - name: status
+        - name: installation-id
+        - name: commit-sha
+
       http:
-        url: http://github-status-proxy.{{ $.Values.namespaces.argocd }}.svc.cluster.local/workflow
+        url: http://github-status-proxy.{{ $.Values.githubStatusProxy.namespace | default $.Values.namespaces.argocd }}.svc.cluster.local:8080/workflow
         method: POST
         headers:
           - name: Content-Type
@@ -77,20 +126,24 @@ spec:
         body: |
           {
             "kind": "workflow",
-            "event": "workflow-{{`{{workflow.status.phase}}`}}",
-            "workflowName": "{{`{{workflow.name}}`}}",
-            "namespace": "{{`{{workflow.namespace}}`}}",
-            "phase": "{{`{{workflow.status.phase}}`}}",
-            "labels": {{`{{toJson workflow.labels}}`}},
-            "annotations": {{`{{toJson workflow.annotations}}`}},
-            "status": {{`{{toJson workflow.status}}`}},
-            "target_url": "{{ $.Values.workflows.baseUrl }}/workflows/{{`{{workflow.namespace}}`}}/{{`{{workflow.name}}`}}"
+            "workflowName": "{{`{{inputs.parameters.workflow-name}}`}}",
+            "namespace": "{{`{{inputs.parameters.namespace}}`}}",
+            "repoURL": "{{`{{inputs.parameters.repo-url}}`}}",          
+            "installationId": "{{`{{inputs.parameters.installation-id}}`}}",
+            "commitSha": "{{`{{inputs.parameters.commit-sha}}`}}",
+            "labels": {{`{{inputs.parameters.labels}}`}},
+            "annotations": {{`{{inputs.parameters.annotations}}`}},
+            "status": "{{`{{inputs.parameters.status}}`}}",
+            "target_url": "{{ $.Values.workflows.baseUrl }}/workflows/{{`{{inputs.parameters.namespace}}`}}/{{`{{inputs.parameters.workflow-name}}`}}"
           }
-    
+
     - name: run-nextflow
       metadata:
         labels:
           calypr.io/commit-sha: "{{`{{workflow.parameters.commit-sha}}`}}"
+          calypr.io/git-before: "{{`{{workflow.parameters.git-before}}`}}"
+          calypr.io/git-after: "{{`{{workflow.parameters.git-after}}`}}"
+          calypr.io/github-installation-id: "{{`{{workflow.parameters.installation-id}}`}}"
           calypr.io/repo: {{ $repoName }}
         annotations:
           calypr.io/repo-url: {{ $reg.repoUrl | quote }}
@@ -113,8 +166,19 @@ spec:
             
             echo "Cloning repo: {{ "{{workflow.parameters.repo-url}}" }}"
             git clone {{ "{{workflow.parameters.repo-url}}" }} repo
+
             cd repo
-            git checkout {{ "{{workflow.parameters.revision}}" }}
+            # Prefer an explicit commit SHA (git-after) if provided, otherwise git-ref, otherwise revision
+            if [ -n "{{ "{{workflow.parameters.commit-sha}}" }}" ]; then
+              echo "Checking out commit SHA: {{ "{{workflow.parameters.commit-sha}}" }}"
+              git checkout "{{ "{{workflow.parameters.commit-sha}}" }}"
+            elif [ -n "{{ "{{workflow.parameters.git-ref}}" }}" ]; then
+              echo "Checking out git ref: {{ "{{workflow.parameters.git-ref}}" }}"
+              git checkout "{{ "{{workflow.parameters.git-ref}}" }}"
+            else
+              echo "Checking out revision: {{ "{{workflow.parameters.revision}}" }}"
+              git checkout "{{ "{{workflow.parameters.revision}}" }}"
+            fi
 
             echo "Artifact bucket: {{ "{{workflow.parameters.artifact-bucket}}" }}"
 
@@ -142,3 +206,4 @@ spec:
             value: "https://{{ "{{workflow.parameters.artifact-endpoint}}" }}"            
 {{- end }}
 {{- end }}
+

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -35,6 +35,9 @@ spec:
       - name: revision
         description: "Git revision (branch, tag, or SHA) to run."
         value: {{ $reg.defaultBranch | default "main" | quote }}
+      - name: commit-sha
+        description: "Git commit SHA that the workflow is executing."
+        value: ""
       - name: pipeline-file
         description: "Nextflow pipeline entry point file (e.g., main.nf, workflow.nf, pipeline.nf)."
         value: "pipelines/push/main.nf"
@@ -57,13 +60,34 @@ spec:
         value: {{ $reg.artifactBucket.region | quote }}
         {{- end }}
 
+  # Exit handler for GitHub status notifications
+  onExit: notify-github-exit
+
   templates:
+    # Exit handler template for GitHub notifications
+    - name: notify-github-exit
+      steps:
+        - - name: notify-status
+            templateRef:
+              name: github-status-notify
+              template: notify-github-status
+              clusterScope: true
+            arguments:
+              parameters:
+                - name: event
+                  value: "workflow-{{`{{workflow.status.phase}}`}}"
+    
     - name: run-nextflow
       metadata:
+        labels:
+          calypr.io/commit-sha: "{{`{{workflow.parameters.commit-sha}}`}}"
+          calypr.io/repo: {{ $repoName }}
         annotations:
+          calypr.io/repo-url: {{ $reg.repoUrl | quote }}
           workflows.argoproj.io/description: |
             Run a Nextflow pipeline from a Git repo using S3-backed
             work and artifact storage derived from RepoRegistration.
+          workflows.argoproj.io/notifications: "enabled"
       container:
         image: nextflow-runner:latest
         imagePullPolicy: IfNotPresent

--- a/helm/argo-stack/values.yaml
+++ b/helm/argo-stack/values.yaml
@@ -545,6 +545,10 @@ workflows:
   # ServiceAccount name used by workflow pods in tenant namespaces
   # This is created automatically per tenant by repoRegistrations
   runnerServiceAccount: wf-runner
+  
+  # Base URL for Argo Workflows UI - used in GitHub commit status target URLs
+  # This should point to your Argo Workflows ingress/UI endpoint
+  baseUrl: "https://argo-workflows.example.com"
 
 # ============================================================================
 # RepoRegistration - Self-Service Repository Onboarding (DECLARATIVE)

--- a/scripts/wf-runner-token-secret.yaml
+++ b/scripts/wf-runner-token-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wf-runner.service-account-token
+  namespace: wf-bwalsh-nextflow-hello-project
+  annotations:
+    kubernetes.io/service-account.name: wf-runner
+type: kubernetes.io/service-account-token

--- a/scripts/wf-runner-workflowtasksets-rbac.yaml
+++ b/scripts/wf-runner-workflowtasksets-rbac.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: wf-runner-workflowtasksets
+  namespace: wf-bwalsh-nextflow-hello-project
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources:
+      - workflowtasksets
+      - workflowtasksets/status
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      # you generally don't need create/delete from the runner,
+      # but it's harmless if you include them:
+      # - create
+      # - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: wf-runner-workflowtasksets-binding
+  namespace: wf-bwalsh-nextflow-hello-project
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: wf-runner-workflowtasksets
+subjects:
+  - kind: ServiceAccount
+    name: wf-runner
+    namespace: wf-bwalsh-nextflow-hello-project
+


### PR DESCRIPTION
# PR: Add ClusterWorkflowTemplate-based GitHub Status Notifications for Workflows

## Summary
This PR introduces a centralized notification mechanism for Argo Workflows using a ClusterWorkflowTemplate.
Workflows across all namespaces can now emit workflow-pending, workflow-succeeded, and workflow-failed events
to the github-status-proxy service, which posts commit statuses to GitHub.

See #128


## Motivation
Provides unified GitHub visibility for workflow executions across multiple tenants,
improving traceability, reproducibility, and CI/CD parity.

## Testing
Deploy the ClusterWorkflowTemplate, RBAC, and example workflow. Confirm:
- Proxy receives webhook events
- GitHub receives commit status updates
- Supports multi-tenant RepoRegistration-based installation resolution
