### PR TITLE
Add references for GitHub status template parameters

### DIFF
--- a/docs/adr/ADR-Workflow-GitHub-Status.md
+++ b/docs/adr/ADR-Workflow-GitHub-Status.md
@@ -1,4 +1,4 @@
-# ADR: Workflow → GitHub Status Integration via ClusterWorkflowTemplate
+# ADR 0003: Workflow → GitHub Status Integration via ClusterWorkflowTemplate
 
 ## Status
 Accepted
@@ -26,8 +26,8 @@ sequenceDiagram
     participant GSP as github-status-proxy
     participant GH as GitHub
 
-    WF->>CWT: onExit notify-github<br/>event=workflow-{phase}
-    CWT->>GSP: HTTP POST /workflow<br/>JSON payload with repo-url, git-sha, tenant
+    WF->>CWT: onExit notify-github
+    event=workflow-{phase}
     GSP->>GSP: Resolve installation via RepoRegistration
     GSP->>GH: Post commit status
     GH-->>User: Status visible on commit/PR
@@ -62,9 +62,9 @@ spec:
             "phase": "{{workflow.status.phase}}",
             "labels": {{toJson workflow.labels}},
             "annotations": {{toJson workflow.annotations}},
-            "status": {{ toJson .workflow.status }},
-            "startedAt": "{{.workflow.status.startedAt}}",
-            "finishedAt": "{{.workflow.status.finishedAt}}"
+            "status": {{toJson workflow.status}},
+            "startedAt": "{{workflow.status.startedAt}}",
+            "finishedAt": "{{workflow.status.finishedAt}}"
           }
 
 ```

--- a/docs/adr/ADR-Workflow-GitHub-Status.md
+++ b/docs/adr/ADR-Workflow-GitHub-Status.md
@@ -1,0 +1,88 @@
+# ADR: Workflow → GitHub Status Integration via ClusterWorkflowTemplate
+
+## Status
+Accepted
+
+## Context
+Argo Workflows run in multiple namespaces and need a centralized way to 
+emit workflow lifecycle events to GitHub using tenant-specific GitHub App 
+credentials stored via RepoRegistration.
+
+## Decision
+Use a `ClusterWorkflowTemplate` to define a shared notification template.
+Workflows reference this via `onExit` handlers.
+
+Notification events:
+- workflow-pending
+- workflow-succeeded
+- workflow-failed
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+    participant WF as Workflow
+    participant CWT as ClusterWorkflowTemplate
+    participant GSP as github-status-proxy
+    participant GH as GitHub
+
+    WF->>CWT: onExit notify-github<br/>event=workflow-{phase}
+    CWT->>GSP: HTTP POST /workflow<br/>JSON payload with repo-url, git-sha, tenant
+    GSP->>GSP: Resolve installation via RepoRegistration
+    GSP->>GH: Post commit status
+    GH-->>User: Status visible on commit/PR
+```
+
+## Consequences
+- Centralizes workflow→GitHub logic
+- Prevents per-namespace duplication
+- Integrates with existing RepoRegistration and GitHub App setup
+
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: github-status-notify
+spec:
+  templates:
+    - name: notify-github-status
+      inputs:
+        parameters:
+          - name: event
+      http:
+        url: http://github-status-proxy.argocd.svc.cluster.local/workflow
+        method: POST
+        body: |
+          {
+            "kind": "workflow",
+            "event": "{{inputs.parameters.event}}",
+            "workflowName": "{{workflow.name}}",
+            "namespace": "{{workflow.namespace}}",
+            "phase": "{{workflow.status.phase}}",
+            "labels": {{toJson workflow.labels}},
+            "annotations": {{toJson workflow.annotations}},
+            "status": {{ toJson .workflow.status }},
+            "startedAt": "{{.workflow.status.startedAt}}",
+            "finishedAt": "{{.workflow.status.finishedAt}}"
+          }
+
+```
+
+```go
+// WorkflowEvent describes the JSON payload sent by Argo Workflows notifications.
+// It matches the templates we discussed earlier.
+type WorkflowEvent struct {
+	Kind        string            `json:"kind"`        // "workflow"
+	Event       string            `json:"event"`       // "workflow-pending" | "workflow-succeeded" | "workflow-failed"
+	Workflow    string            `json:"workflowName"`
+	Namespace   string            `json:"namespace"`
+	Phase       string            `json:"phase"`
+	StartedAt   string            `json:"startedAt,omitempty"`
+	FinishedAt  string            `json:"finishedAt,omitempty"`
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+	// Status is intentionally left as raw JSON so we don't need a full struct.
+	Status any `json:"status"`
+}
+```

--- a/docs/adr/ADR-Workflow-GitHub-Status.md
+++ b/docs/adr/ADR-Workflow-GitHub-Status.md
@@ -86,3 +86,11 @@ type WorkflowEvent struct {
 	Status any `json:"status"`
 }
 ```
+
+## References
+
+- [Argo Workflows: ClusterWorkflowTemplate](https://argo-workflows.readthedocs.io/en/latest/cluster-workflow-templates/)
+- [Argo Workflows: HTTP Template](https://argo-workflows.readthedocs.io/en/latest/http-template/)
+- [Argo Workflows: Workflow Lifecycle Hooks](https://argo-workflows.readthedocs.io/en/latest/lifecyclehook/)
+- [GitHub Issue #128](https://github.com/calypr/argo-helm/issues/128)
+- [ADR 0001: GitHub Status Proxy](0001-github-status-proxy-for-multi-tenant-github-apps.md)

--- a/github-status-proxy/main_test.go
+++ b/github-status-proxy/main_test.go
@@ -139,3 +139,173 @@ func TestValidateRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateWorkflowEvent(t *testing.T) {
+	tests := []struct {
+		name    string
+		event   WorkflowEvent
+		wantErr bool
+	}{
+		{
+			name: "Valid workflow event",
+			event: WorkflowEvent{
+				Kind:      "workflow",
+				Event:     "workflow-succeeded",
+				Workflow:  "test-workflow",
+				Namespace: "default",
+				Phase:     "Succeeded",
+				Labels: map[string]string{
+					"calypr.io/commit-sha": "abc123",
+					"calypr.io/repo":       "calypr/argo-helm",
+				},
+				Annotations: map[string]string{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Missing kind",
+			event: WorkflowEvent{
+				Event:     "workflow-succeeded",
+				Workflow:  "test-workflow",
+				Namespace: "default",
+				Phase:     "Succeeded",
+				Labels:    map[string]string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Wrong kind",
+			event: WorkflowEvent{
+				Kind:      "task",
+				Event:     "workflow-succeeded",
+				Workflow:  "test-workflow",
+				Namespace: "default",
+				Phase:     "Succeeded",
+				Labels:    map[string]string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Missing event",
+			event: WorkflowEvent{
+				Kind:      "workflow",
+				Workflow:  "test-workflow",
+				Namespace: "default",
+				Phase:     "Succeeded",
+				Labels:    map[string]string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Missing workflow name",
+			event: WorkflowEvent{
+				Kind:      "workflow",
+				Event:     "workflow-succeeded",
+				Namespace: "default",
+				Phase:     "Succeeded",
+				Labels:    map[string]string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Missing namespace",
+			event: WorkflowEvent{
+				Kind:     "workflow",
+				Event:    "workflow-succeeded",
+				Workflow: "test-workflow",
+				Phase:    "Succeeded",
+				Labels:   map[string]string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Missing phase",
+			event: WorkflowEvent{
+				Kind:      "workflow",
+				Event:     "workflow-succeeded",
+				Workflow:  "test-workflow",
+				Namespace: "default",
+				Labels:    map[string]string{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Nil labels",
+			event: WorkflowEvent{
+				Kind:      "workflow",
+				Event:     "workflow-succeeded",
+				Workflow:  "test-workflow",
+				Namespace: "default",
+				Phase:     "Succeeded",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWorkflowEvent(&tt.event)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateWorkflowEvent() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMapWorkflowPhaseToGitHubState(t *testing.T) {
+	tests := []struct {
+		name      string
+		phase     string
+		wantState string
+	}{
+		{
+			name:      "Succeeded phase",
+			phase:     "Succeeded",
+			wantState: "success",
+		},
+		{
+			name:      "Failed phase",
+			phase:     "Failed",
+			wantState: "failure",
+		},
+		{
+			name:      "Error phase",
+			phase:     "Error",
+			wantState: "failure",
+		},
+		{
+			name:      "Running phase",
+			phase:     "Running",
+			wantState: "pending",
+		},
+		{
+			name:      "Pending phase",
+			phase:     "Pending",
+			wantState: "pending",
+		},
+		{
+			name:      "Unknown phase",
+			phase:     "Unknown",
+			wantState: "error",
+		},
+		{
+			name:      "Lowercase succeeded",
+			phase:     "succeeded",
+			wantState: "success",
+		},
+		{
+			name:      "Lowercase failed",
+			phase:     "failed",
+			wantState: "failure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := mapWorkflowPhaseToGitHubState(tt.phase)
+			if state != tt.wantState {
+				t.Errorf("mapWorkflowPhaseToGitHubState() = %v, want %v", state, tt.wantState)
+			}
+		})
+	}
+}

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
@@ -18,10 +18,6 @@ metadata:
 spec:
   templates:
     - name: notify-github-status
-      inputs:
-        parameters:
-          - name: phase
-            description: "Workflow status phase (e.g., Succeeded, Failed, Pending)"
       http:
         url: http://github-status-proxy.{{ .Values.namespaces.argocd }}.svc.cluster.local/workflow
         method: POST
@@ -31,10 +27,10 @@ spec:
         body: |
           {
             "kind": "workflow",
-            "event": "workflow-{{`{{inputs.parameters.phase}}`}}",
+            "event": "workflow-{{`{{workflow.status.phase}}`}}",
             "workflowName": "{{`{{workflow.name}}`}}",
             "namespace": "{{`{{workflow.namespace}}`}}",
-            "phase": "{{`{{inputs.parameters.phase}}`}}",
+            "phase": "{{`{{workflow.status.phase}}`}}",
             "labels": {{`{{toJson workflow.labels}}`}},
             "annotations": {{`{{toJson workflow.annotations}}`}},
             "status": {{`{{toJson workflow.status}}`}},

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
@@ -18,6 +18,20 @@ metadata:
 spec:
   templates:
     - name: notify-github-status
+      # Inputs are explicitly enumerated so that caller workflows can pass
+      # their metadata/status when invoking this ClusterWorkflowTemplate via
+      # templateRef. Argo requires parameters to be provided by the caller; they
+      # cannot be resolved from the callee's context. See Argo docs:
+      # https://argo-workflows.readthedocs.io/en/stable/workflow-templates/#referencing-other-templates
+      inputs:
+        parameters:
+          - name: workflow-name
+          - name: workflow-namespace
+          - name: workflow-phase
+          - name: workflow-labels
+          - name: workflow-annotations
+          - name: workflow-status
+          - name: target-url
       http:
         url: http://github-status-proxy.{{ .Values.namespaces.argocd }}.svc.cluster.local/workflow
         method: POST
@@ -27,13 +41,13 @@ spec:
         body: |
           {
             "kind": "workflow",
-            "event": "workflow-{{`{{workflow.status.phase}}`}}",
-            "workflowName": "{{`{{workflow.name}}`}}",
-            "namespace": "{{`{{workflow.namespace}}`}}",
-            "phase": "{{`{{workflow.status.phase}}`}}",
-            "labels": {{`{{toJson workflow.labels}}`}},
-            "annotations": {{`{{toJson workflow.annotations}}`}},
-            "status": {{`{{toJson workflow.status}}`}},
-            "target_url": "{{ .Values.workflows.baseUrl }}/workflows/{{`{{workflow.namespace}}`}}/{{`{{workflow.name}}`}}"
+            "event": "workflow-{{`{{inputs.parameters.workflow-phase}}`}}",
+            "workflowName": "{{`{{inputs.parameters.workflow-name}}`}}",
+            "namespace": "{{`{{inputs.parameters.workflow-namespace}}`}}",
+            "phase": "{{`{{inputs.parameters.workflow-phase}}`}}",
+            "labels": {{`{{inputs.parameters.workflow-labels}}`}},
+            "annotations": {{`{{inputs.parameters.workflow-annotations}}`}},
+            "status": {{`{{inputs.parameters.workflow-status}}`}},
+            "target_url": "{{`{{inputs.parameters.target-url}}`}}"
           }
 

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
@@ -22,9 +22,17 @@ metadata:
 spec:
   templates:
     - name: notify-github-status
-      # Reference workflow status/metadata directly so Argo resolves the values
-      # at exit-handler execution time instead of submission time. See Argo's
-      # templateRef guidance: https://argo-workflows.readthedocs.io/en/stable/workflow-templates/#referencing-other-templates
+      # Accept workflow context via parameters because templateRef does not implicitly
+      # inherit caller variables. See Argo's templateRef guidance:
+      # https://argo-workflows.readthedocs.io/en/stable/workflow-templates/#referencing-other-templates
+      inputs:
+        parameters:
+          - name: workflow-name
+          - name: workflow-namespace
+          - name: workflow-phase
+          - name: workflow-labels
+          - name: workflow-annotations
+          - name: workflow-status
       http:
         url: http://github-status-proxy.{{ $.Values.namespaces.argocd }}.svc.cluster.local/workflow
         method: POST
@@ -34,15 +42,15 @@ spec:
         body: |
           {
             "kind": "workflow",
-            "event": "workflow-{{`{{workflow.status.phase}}`}}",
-            "workflowName": "{{`{{workflow.name}}`}}",
-            "namespace": "{{`{{workflow.namespace}}`}}",
-            "phase": "{{`{{workflow.status.phase}}`}}",
-            "labels": {{`{{toJson workflow.labels}}`}},
-            "annotations": {{`{{toJson workflow.annotations}}`}},
-            "status": {{`{{toJson workflow.status}}`}},
+            "event": "workflow-{{`{{inputs.parameters.workflow-phase}}`}}",
+            "workflowName": "{{`{{inputs.parameters.workflow-name}}`}}",
+            "namespace": "{{`{{inputs.parameters.workflow-namespace}}`}}",
+            "phase": "{{`{{inputs.parameters.workflow-phase}}`}}",
+            "labels": {{`{{inputs.parameters.workflow-labels}}`}},
+            "annotations": {{`{{inputs.parameters.workflow-annotations}}`}},
+            "status": {{`{{inputs.parameters.workflow-status}}`}},
             {{- if $baseUrl }}
-            "target_url": "{{ printf "%s/workflows/%s/%s" $baseUrl "{{workflow.namespace}}" "{{workflow.name}}" }}"
+            "target_url": "{{ printf "%s/workflows/%s/%s" $baseUrl "{{inputs.parameters.workflow-namespace}}" "{{inputs.parameters.workflow-name}}" }}"
             {{- else }}
             "target_url": ""
             {{- end }}

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
@@ -33,7 +33,7 @@ spec:
           - name: workflow-status
           - name: target-url
       http:
-        url: http://github-status-proxy.{{ .Values.namespaces.argocd }}.svc.cluster.local/workflow
+        url: http://github-status-proxy.{{ $.Values.namespaces.argocd }}.svc.cluster.local/workflow
         method: POST
         headers:
           - name: Content-Type

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
@@ -38,8 +38,6 @@ spec:
             "labels": {{`{{toJson workflow.labels}}`}},
             "annotations": {{`{{toJson workflow.annotations}}`}},
             "status": {{`{{toJson workflow.status}}`}},
-            "startedAt": "{{`{{workflow.status.startedAt}}`}}",
-            "finishedAt": "{{`{{workflow.status.finishedAt}}`}}",
             "target_url": "{{ .Values.workflows.baseUrl }}/workflows/{{`{{workflow.namespace}}`}}/{{`{{workflow.name}}`}}"
           }
 

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
@@ -1,0 +1,45 @@
+{{- /*
+ClusterWorkflowTemplate for GitHub Status Notifications
+Provides a centralized notification mechanism for workflows across all namespaces.
+See ADR 0003 for design rationale.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: github-status-notify
+  labels:
+    app.kubernetes.io/name: argo-stack
+    app.kubernetes.io/part-of: argo-workflows
+    app.kubernetes.io/component: notifications
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "10"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  templates:
+    - name: notify-github-status
+      inputs:
+        parameters:
+          - name: event
+            description: "Event type: workflow-{phase} where phase is the workflow status phase (e.g., workflow-Succeeded, workflow-Failed)"
+      http:
+        url: http://github-status-proxy.{{ .Values.namespaces.argocd }}.svc.cluster.local/workflow
+        method: POST
+        headers:
+          - name: Content-Type
+            value: "application/json"
+        body: |
+          {
+            "kind": "workflow",
+            "event": "{{`{{inputs.parameters.event}}`}}",
+            "workflowName": "{{`{{workflow.name}}`}}",
+            "namespace": "{{`{{workflow.namespace}}`}}",
+            "phase": "{{`{{workflow.status.phase}}`}}",
+            "labels": {{`{{toJson workflow.labels}}`}},
+            "annotations": {{`{{toJson workflow.annotations}}`}},
+            "status": {{`{{toJson workflow.status}}`}},
+            "startedAt": "{{`{{workflow.status.startedAt}}`}}",
+            "finishedAt": "{{`{{workflow.status.finishedAt}}`}}",
+            "target_url": "{{ .Values.workflows.baseUrl }}/workflows/{{`{{workflow.namespace}}`}}/{{`{{workflow.name}}`}}"
+          }
+

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
@@ -20,8 +20,8 @@ spec:
     - name: notify-github-status
       inputs:
         parameters:
-          - name: event
-            description: "Event type: workflow-{phase} where phase is the workflow status phase (e.g., workflow-Succeeded, workflow-Failed)"
+          - name: phase
+            description: "Workflow status phase (e.g., Succeeded, Failed, Pending)"
       http:
         url: http://github-status-proxy.{{ .Values.namespaces.argocd }}.svc.cluster.local/workflow
         method: POST
@@ -31,10 +31,10 @@ spec:
         body: |
           {
             "kind": "workflow",
-            "event": "{{`{{inputs.parameters.event}}`}}",
+            "event": "workflow-{{`{{inputs.parameters.phase}}`}}",
             "workflowName": "{{`{{workflow.name}}`}}",
             "namespace": "{{`{{workflow.namespace}}`}}",
-            "phase": "{{`{{workflow.status.phase}}`}}",
+            "phase": "{{`{{inputs.parameters.phase}}`}}",
             "labels": {{`{{toJson workflow.labels}}`}},
             "annotations": {{`{{toJson workflow.annotations}}`}},
             "status": {{`{{toJson workflow.status}}`}},

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-github-notifications.yaml
@@ -3,6 +3,10 @@ ClusterWorkflowTemplate for GitHub Status Notifications
 Provides a centralized notification mechanism for workflows across all namespaces.
 See ADR 0003 for design rationale.
 */ -}}
+{{- $baseUrl := "" }}
+{{- if and $.Values.workflows $.Values.workflows.baseUrl }}
+{{- $baseUrl = $.Values.workflows.baseUrl }}
+{{- end }}
 apiVersion: argoproj.io/v1alpha1
 kind: ClusterWorkflowTemplate
 metadata:
@@ -18,20 +22,9 @@ metadata:
 spec:
   templates:
     - name: notify-github-status
-      # Inputs are explicitly enumerated so that caller workflows can pass
-      # their metadata/status when invoking this ClusterWorkflowTemplate via
-      # templateRef. Argo requires parameters to be provided by the caller; they
-      # cannot be resolved from the callee's context. See Argo docs:
-      # https://argo-workflows.readthedocs.io/en/stable/workflow-templates/#referencing-other-templates
-      inputs:
-        parameters:
-          - name: workflow-name
-          - name: workflow-namespace
-          - name: workflow-phase
-          - name: workflow-labels
-          - name: workflow-annotations
-          - name: workflow-status
-          - name: target-url
+      # Reference workflow status/metadata directly so Argo resolves the values
+      # at exit-handler execution time instead of submission time. See Argo's
+      # templateRef guidance: https://argo-workflows.readthedocs.io/en/stable/workflow-templates/#referencing-other-templates
       http:
         url: http://github-status-proxy.{{ $.Values.namespaces.argocd }}.svc.cluster.local/workflow
         method: POST
@@ -41,13 +34,17 @@ spec:
         body: |
           {
             "kind": "workflow",
-            "event": "workflow-{{`{{inputs.parameters.workflow-phase}}`}}",
-            "workflowName": "{{`{{inputs.parameters.workflow-name}}`}}",
-            "namespace": "{{`{{inputs.parameters.workflow-namespace}}`}}",
-            "phase": "{{`{{inputs.parameters.workflow-phase}}`}}",
-            "labels": {{`{{inputs.parameters.workflow-labels}}`}},
-            "annotations": {{`{{inputs.parameters.workflow-annotations}}`}},
-            "status": {{`{{inputs.parameters.workflow-status}}`}},
-            "target_url": "{{`{{inputs.parameters.target-url}}`}}"
+            "event": "workflow-{{`{{workflow.status.phase}}`}}",
+            "workflowName": "{{`{{workflow.name}}`}}",
+            "namespace": "{{`{{workflow.namespace}}`}}",
+            "phase": "{{`{{workflow.status.phase}}`}}",
+            "labels": {{`{{toJson workflow.labels}}`}},
+            "annotations": {{`{{toJson workflow.annotations}}`}},
+            "status": {{`{{toJson workflow.status}}`}},
+            {{- if $baseUrl }}
+            "target_url": "{{ printf "%s/workflows/%s/%s" $baseUrl "{{workflow.namespace}}" "{{workflow.name}}" }}"
+            {{- else }}
+            "target_url": ""
+            {{- end }}
           }
 

--- a/helm/argo-stack/templates/workflows/clusterworkflowtemplate-rbac.yaml
+++ b/helm/argo-stack/templates/workflows/clusterworkflowtemplate-rbac.yaml
@@ -1,0 +1,82 @@
+{{- /*
+ClusterRole and ClusterRoleBinding for accessing ClusterWorkflowTemplates
+This allows Argo Events sensors and workflow service accounts to reference
+ClusterWorkflowTemplates when submitting and executing workflows.
+See ADR 0003 for context on ClusterWorkflowTemplate-based notifications.
+*/ -}}
+---
+# ClusterRole for reading ClusterWorkflowTemplates
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusterworkflowtemplate-reader
+  labels:
+    app.kubernetes.io/name: argo-stack
+    app.kubernetes.io/part-of: argo-workflows
+    app.kubernetes.io/component: rbac
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources: ["clusterworkflowtemplates"]
+    verbs: ["get", "list", "watch"]
+
+---
+# ClusterRoleBinding for Argo Events sensor service account
+# This allows sensors to submit workflows that reference ClusterWorkflowTemplates
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argo-events-clusterworkflowtemplate-reader
+  labels:
+    app.kubernetes.io/name: argo-stack
+    app.kubernetes.io/part-of: argo-workflows
+    app.kubernetes.io/component: rbac
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterworkflowtemplate-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.events.github.sensorServiceAccount | default "default" }}
+    namespace: {{ .Values.namespaces.argoEvents | default "argo-events" }}
+
+{{- if .Values.repoRegistrations }}
+{{- range $reg := .Values.repoRegistrations }}
+{{- $namespace := include "argo-stack.repoRegistration.namespace" $reg }}
+---
+# ClusterRoleBinding for workflow runner service account in tenant namespace: {{ $reg.name }}
+# This allows workflows to execute templates that reference ClusterWorkflowTemplates
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wf-runner-clusterworkflowtemplate-{{ $reg.name }}
+  labels:
+    app.kubernetes.io/name: {{ $reg.name }}
+    app.kubernetes.io/part-of: argo-stack
+    app.kubernetes.io/component: rbac
+    {{- if $reg.tenant }}
+    tenant: {{ $reg.tenant }}
+    {{- end }}
+    source: repo-registration
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation
+    repo-registration/name: {{ $reg.name | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterworkflowtemplate-reader
+subjects:
+  - kind: ServiceAccount
+    name: wf-runner
+    namespace: {{ $namespace }}
+{{- end }}
+{{- end }}

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -72,10 +72,6 @@ spec:
               name: github-status-notify
               template: notify-github-status
               clusterScope: true
-            arguments:
-              parameters:
-                - name: phase
-                  value: "{{`{{workflow.status.phase}}`}}"
     
     - name: run-nextflow
       metadata:

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -74,8 +74,8 @@ spec:
               clusterScope: true
             arguments:
               parameters:
-                - name: event
-                  value: "workflow-{{`{{workflow.status.phase}}`}}"
+                - name: phase
+                  value: "{{`{{workflow.status.phase}}`}}"
     
     - name: run-nextflow
       metadata:

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -7,7 +7,10 @@ This ensures workflows can reference templates within the same namespace.
 {{- range $reg := .Values.repoRegistrations }}
 {{- $namespace := include "argo-stack.repoRegistration.namespace" $reg }}
 {{- $repoName := $reg.name }}
-{{- $baseUrl := dig "workflows" "baseUrl" "" $.Values }}
+{{- $baseUrl := "" }}
+{{- if and $.Values.workflows $.Values.workflows.baseUrl }}
+{{- $baseUrl = $.Values.workflows.baseUrl }}
+{{- end }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -72,6 +72,25 @@ spec:
               name: github-status-notify
               template: notify-github-status
               clusterScope: true
+            # Pass workflow metadata/status as parameters because templateRef
+            # cannot access the caller workflow's context implicitly. Argo docs:
+            # https://argo-workflows.readthedocs.io/en/stable/workflow-templates/#referencing-other-templates
+            arguments:
+              parameters:
+                - name: workflow-name
+                  value: "{{`{{workflow.name}}`}}"
+                - name: workflow-namespace
+                  value: "{{`{{workflow.namespace}}`}}"
+                - name: workflow-phase
+                  value: "{{`{{workflow.status.phase}}`}}"
+                - name: workflow-labels
+                  value: "{{`{{toJson workflow.labels}}`}}"
+                - name: workflow-annotations
+                  value: "{{`{{toJson workflow.annotations}}`}}"
+                - name: workflow-status
+                  value: "{{`{{toJson workflow.status}}`}}"
+                - name: target-url
+                  value: "{{ .Values.workflows.baseUrl }}/workflows/{{`{{workflow.namespace}}`}}/{{`{{workflow.name}}`}}"
     
     - name: run-nextflow
       metadata:

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -7,6 +7,7 @@ This ensures workflows can reference templates within the same namespace.
 {{- range $reg := .Values.repoRegistrations }}
 {{- $namespace := include "argo-stack.repoRegistration.namespace" $reg }}
 {{- $repoName := $reg.name }}
+{{- $baseUrl := dig "workflows" "baseUrl" "" $.Values }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
@@ -90,7 +91,7 @@ spec:
                 - name: workflow-status
                   value: "{{`{{toJson workflow.status}}`}}"
                 - name: target-url
-                  value: "{{ .Values.workflows.baseUrl }}/workflows/{{`{{workflow.namespace}}`}}/{{`{{workflow.name}}`}}"
+                  value: "{{ $baseUrl }}/workflows/{{`{{workflow.namespace}}`}}/{{`{{workflow.name}}`}}"
     
     - name: run-nextflow
       metadata:

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -7,6 +7,10 @@ This ensures workflows can reference templates within the same namespace.
 {{- range $reg := .Values.repoRegistrations }}
 {{- $namespace := include "argo-stack.repoRegistration.namespace" $reg }}
 {{- $repoName := $reg.name }}
+{{- $baseUrl := "" }}
+{{- if and $.Values.workflows $.Values.workflows.baseUrl }}
+{{- $baseUrl = $.Values.workflows.baseUrl }}
+{{- end }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
@@ -64,29 +68,39 @@ spec:
   onExit: notify-github-exit
 
   templates:
+    # Inline notification step so workflow.status.* is resolved inside the caller workflow
+    # See Argo variables reference: https://argo-workflows.readthedocs.io/en/stable/variables/#workflow
+    # See exit handler behavior: https://argo-workflows.readthedocs.io/en/stable/exit-handlers/
+    - name: notify-github-status
+      http:
+        url: http://github-status-proxy.{{ $.Values.namespaces.argocd }}.svc.cluster.local/workflow
+        method: POST
+        headers:
+          - name: Content-Type
+            value: "application/json"
+        body: |
+          {
+            "kind": "workflow",
+            "event": "workflow-{{ `{{workflow.status.phase}}` }}",
+            "workflowName": "{{ `{{workflow.name}}` }}",
+            "namespace": "{{ `{{workflow.namespace}}` }}",
+            "phase": "{{ `{{workflow.status.phase}}` }}",
+            "labels": {{ `{{toJson workflow.labels}}` }},
+            "annotations": {{ `{{toJson workflow.annotations}}` }},
+            "status": {{ `{{toJson workflow.status}}` }},
+            {{- if $baseUrl }}
+            "target_url": "{{ printf "%s/workflows/%s/%s" $baseUrl "{{workflow.namespace}}" "{{workflow.name}}" }}"
+            {{- else }}
+            "target_url": ""
+            {{- end }}
+          }
+
     # Exit handler template for GitHub notifications
     - name: notify-github-exit
       steps:
         - - name: notify-status
-            templateRef:
-              name: github-status-notify
-              template: notify-github-status
-              clusterScope: true
-            arguments:
-              parameters:
-                - name: workflow-name
-                  value: "{{ `{{workflow.name}}` }}"
-                - name: workflow-namespace
-                  value: "{{ `{{workflow.namespace}}` }}"
-                - name: workflow-phase
-                  value: "{{ `{{workflow.status.phase}}` }}"
-                - name: workflow-labels
-                  value: "{{ `{{toJson workflow.labels}}` }}"
-                - name: workflow-annotations
-                  value: "{{ `{{toJson workflow.annotations}}` }}"
-                - name: workflow-status
-                  value: "{{ `{{toJson workflow.status}}` }}"
-    
+            template: notify-github-status
+
     - name: run-nextflow
       metadata:
         labels:

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -7,10 +7,6 @@ This ensures workflows can reference templates within the same namespace.
 {{- range $reg := .Values.repoRegistrations }}
 {{- $namespace := include "argo-stack.repoRegistration.namespace" $reg }}
 {{- $repoName := $reg.name }}
-{{- $baseUrl := "" }}
-{{- if and $.Values.workflows $.Values.workflows.baseUrl }}
-{{- $baseUrl = $.Values.workflows.baseUrl }}
-{{- end }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
@@ -76,25 +72,6 @@ spec:
               name: github-status-notify
               template: notify-github-status
               clusterScope: true
-            # Pass workflow metadata/status as parameters because templateRef
-            # cannot access the caller workflow's context implicitly. Argo docs:
-            # https://argo-workflows.readthedocs.io/en/stable/workflow-templates/#referencing-other-templates
-            arguments:
-              parameters:
-                - name: workflow-name
-                  value: "{{`{{workflow.name}}`}}"
-                - name: workflow-namespace
-                  value: "{{`{{workflow.namespace}}`}}"
-                - name: workflow-phase
-                  value: "{{`{{workflow.status.phase}}`}}"
-                - name: workflow-labels
-                  value: "{{`{{toJson workflow.labels}}`}}"
-                - name: workflow-annotations
-                  value: "{{`{{toJson workflow.annotations}}`}}"
-                - name: workflow-status
-                  value: "{{`{{toJson workflow.status}}`}}"
-                - name: target-url
-                  value: "{{ $baseUrl }}/workflows/{{`{{workflow.namespace}}`}}/{{`{{workflow.name}}`}}"
     
     - name: run-nextflow
       metadata:

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -35,6 +35,9 @@ spec:
       - name: revision
         description: "Git revision (branch, tag, or SHA) to run."
         value: {{ $reg.defaultBranch | default "main" | quote }}
+      - name: commit-sha
+        description: "Git commit SHA that the workflow is executing."
+        value: ""
       - name: pipeline-file
         description: "Nextflow pipeline entry point file (e.g., main.nf, workflow.nf, pipeline.nf)."
         value: "pipelines/push/main.nf"
@@ -57,13 +60,34 @@ spec:
         value: {{ $reg.artifactBucket.region | quote }}
         {{- end }}
 
+  # Exit handler for GitHub status notifications
+  onExit: notify-github-exit
+
   templates:
+    # Exit handler template for GitHub notifications
+    - name: notify-github-exit
+      steps:
+        - - name: notify-status
+            templateRef:
+              name: github-status-notify
+              template: notify-github-status
+              clusterScope: true
+            arguments:
+              parameters:
+                - name: event
+                  value: "workflow-{{`{{workflow.status.phase}}`}}"
+    
     - name: run-nextflow
       metadata:
+        labels:
+          calypr.io/commit-sha: "{{`{{workflow.parameters.commit-sha}}`}}"
+          calypr.io/repo: {{ $repoName }}
         annotations:
+          calypr.io/repo-url: {{ $reg.repoUrl | quote }}
           workflows.argoproj.io/description: |
             Run a Nextflow pipeline from a Git repo using S3-backed
             work and artifact storage derived from RepoRegistration.
+          workflows.argoproj.io/notifications: "enabled"
       container:
         image: nextflow-runner:latest
         imagePullPolicy: IfNotPresent

--- a/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
+++ b/helm/argo-stack/templates/workflows/per-tenant-workflowtemplates.yaml
@@ -72,6 +72,20 @@ spec:
               name: github-status-notify
               template: notify-github-status
               clusterScope: true
+            arguments:
+              parameters:
+                - name: workflow-name
+                  value: "{{ `{{workflow.name}}` }}"
+                - name: workflow-namespace
+                  value: "{{ `{{workflow.namespace}}` }}"
+                - name: workflow-phase
+                  value: "{{ `{{workflow.status.phase}}` }}"
+                - name: workflow-labels
+                  value: "{{ `{{toJson workflow.labels}}` }}"
+                - name: workflow-annotations
+                  value: "{{ `{{toJson workflow.annotations}}` }}"
+                - name: workflow-status
+                  value: "{{ `{{toJson workflow.status}}` }}"
     
     - name: run-nextflow
       metadata:

--- a/helm/argo-stack/values.yaml
+++ b/helm/argo-stack/values.yaml
@@ -545,6 +545,10 @@ workflows:
   # ServiceAccount name used by workflow pods in tenant namespaces
   # This is created automatically per tenant by repoRegistrations
   runnerServiceAccount: wf-runner
+  
+  # Base URL for Argo Workflows UI - used in GitHub commit status target URLs
+  # This should point to your Argo Workflows ingress/UI endpoint
+  baseUrl: "https://argo-workflows.example.com"
 
 # ============================================================================
 # RepoRegistration - Self-Service Repository Onboarding (DECLARATIVE)


### PR DESCRIPTION
## Summary
- document the requirement to pass workflow metadata when invoking the shared GitHub status ClusterWorkflowTemplate
- add an inline link to the Argo WorkflowTemplate docs showing why parameters must be provided by callers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693db6e9561c832f87bdcc1223425a27)